### PR TITLE
feat: add multi environment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Environment Variables ###
+.env

--- a/docker-compose-stage.yml
+++ b/docker-compose-stage.yml
@@ -1,0 +1,32 @@
+services:
+  postgres:
+    image: postgres:latest
+    container_name: concell_system_postgres_db
+    environment:
+      POSTGRES_DB: ${STAGE_DB_NAME}
+      POSTGRES_USER: ${STAGE_DB_USERNAME}
+      POSTGRES_PASSWORD: ${STAGE_DB_PASSWORD}
+      TZ: "UTC-4"
+    ports:
+      - 3434:3434
+    command: -p 3434
+    profiles:
+      - stage
+    env_file:
+      - .env
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: concell_system_pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${STAGE_PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${STAGE_PGADMIN_PASSWORD}
+      PGADMIN_LISTEN_PORT: ${STAGE_PGADMIN_PORT}
+    ports:
+      - 4444:4444
+    depends_on:
+      - postgres
+    profiles:
+      - stage
+    env_file:
+      - .env

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,12 @@
+spring.jpa.database=POSTGRESQL
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=update
+
+spring.datasource.drive=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://localhost:5432/basedatosnuevo
+spring.datasource.username=postgres
+spring.datasource.password=system
+
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+server.port=8080

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -1,0 +1,13 @@
+server.port=8181
+
+spring.datasource.url=jdbc:postgresql://localhost:3434/concell_system_db
+spring.datasource.username=user
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
+spring.jpa.hibernate.ddl-auto=update
+
+spring.sql.init.mode=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,3 @@
-spring.jpa.database=POSTGRESQL
-spring.jpa.show-sql=false
-spring.jpa.hibernate.ddl-auto=update
+spring.application.name=concell_system_api
 
-spring.datasource.drive=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://localhost:5432/basedatosnuevo
-spring.datasource.username=postgres
-spring.datasource.password=system
-
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
-
-server.port=8080
+spring.profiles.active=stage


### PR DESCRIPTION
This PR is on charge of adding two environments, such as dev and stage.
- dev environment runs on 8080 port.
- stage environment runs on 8181 port.

Also, stage environment uses **Docker** for running **PostgreSQL** (database) and **PgAdmin**.
To run it, you can use the following command:
```
docker compose -f docker-compose-stage.yml up pgadmin
```
And for the application, just run using the IDE or the following command:
```
mvn spring-boot:run
```