### PR TITLE
chore: add `Swagger` configuration for API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,18 +22,21 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<!-- JPA -->
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-data-jpa</artifactId>
 		    <version>2.7.1</version>
 		</dependency>
+
 		<!-- JDBC -->
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-jdbc</artifactId>
 		    <version>2.7.1</version>
 		</dependency>
+
 		<!-- POSTGRESQL -->
 		<dependency>
 		    <groupId>org.postgresql</groupId>
@@ -45,9 +48,8 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
-		
-		
+
+		<!-- SECURITY -->
 		<!-- 
 			<dependency>
 		    <groupId>org.springframework.boot</groupId>
@@ -61,9 +63,13 @@
 		    <version>0.9.1</version>
 		</dependency>
 		-->
-		<!-- SECURITY -->
-	
 
+		<!-- Swagger UI -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.7.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/taller1/proy1/config/SwaggerConfig.java
+++ b/src/main/java/com/taller1/proy1/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.taller1.proy1.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+            .info(new Info()
+                    .title("Concell System API")
+                    .version("1.0")
+                    .description("An application to manage the inventory of a technology store."));
+  }
+}


### PR DESCRIPTION
This PR is dedicated to adding Swagger configuration for API documentation, which helps to see the whole endpoints of the API. 
For that, the PR implements an extra dependency and a specific class to show the API details, `SwaggerConfig`.

You can see them when running the project on stage environment at:
```
http://localhost:8181/swagger-ui/index.html#/
```